### PR TITLE
Pass item index #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import GridView from 'react-native-super-grid';
 <GridView
   itemWidth={130}
   items={[1,2,3,4,5,6]}
-  renderRow={item => (<Text>{item}</Text>)}
+  renderItem={item => (<Text>{item}</Text>)}
 />
 ```
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class SuperGrid extends Component {
       width: containerWidth,
       paddingRight: spacing,
     };
-    let itemStyle = { };
+    let itemStyle = {};
     if (fixed) {
       itemStyle = {
         width: itemWidth,
@@ -63,7 +63,7 @@ class SuperGrid extends Component {
         {(data || []).map((item, i) => (
           <View key={`${rowId}_${i}`} style={columnStyle}>
             <View style={itemStyle}>
-              {this.props.renderItem(item)}
+              {this.props.renderItem(item, i)}
             </View>
           </View>
         ))}


### PR DESCRIPTION
the index from the data mapping function is useful in giving grid items different styles based on their index.

```
<View style={rowStyle}>
        {(data || []).map((item, i) => (
          <View key={`${rowId}_${i}`} style={columnStyle}>
            <View style={itemStyle}>
              {this.props.renderItem(item,i)}
            </View>
          </View>
        ))}
      </View>
```

Since it is already accessible, suggest passing it along.

This PR also addresses an error in the readme file.

Fixes #2 